### PR TITLE
Support python3.

### DIFF
--- a/nvm/pmem.py
+++ b/nvm/pmem.py
@@ -8,6 +8,7 @@
 .. seealso:: `NVML libpmem documentation <http://pmem.io/nvml/libpmem/libpmem.3.html>`_.
 """
 import os
+import sys
 from _pmem import lib, ffi
 
 #: Create the named file if it does not exist.
@@ -195,6 +196,8 @@ def map_file(file_name, file_size, flags, mode):
     ret_mappend_len = ffi.new("size_t *")
     ret_is_pmem = ffi.new("int *")
 
+    if sys.version_info[0] > 2 and hasattr(file_name, 'encode'):
+        file_name = file_name.encode(errors='surrogateescape')
     ret = lib.pmem_map_file(file_name, file_size, flags, mode,
                             ret_mappend_len, ret_is_pmem)
 


### PR DESCRIPTION
These changes allow the unit tests to run successfully using python3.4,
without affecting 2.7 support.  I'm not 100% sure if it is enough for
full python3 support since then only thing I've run with it is the tests,
and I'm not clear how complete they are.

Only one change is to the library code, the rest of the changes just
generalize the syntax used in the tests to syntax that is supported by
both python2 and python3.  The library change adds support for python3
string filenames without changing the python2 filename support.
